### PR TITLE
FastMemcpy{,_Avx}.c: Mark `memcpy()` as `dllimport` on MinGW and ming…

### DIFF
--- a/FastMemcpy.c
+++ b/FastMemcpy.c
@@ -24,6 +24,16 @@
 #error it can only be compiled under windows or unix
 #endif
 
+#ifdef __MINGW32__
+/* On MinGW and mingw-w64 targets, `memcpy()` is imported from MSVCRT.DLL.
+ * With regard to benchmarking purposes, we have to eliminate the overhead
+ * of implicit importation by specifying `dllexport` explicitly.
+ *
+ * Reference: https://gcc.gnu.org/onlinedocs/gcc/Microsoft-Windows-Function-Attributes.html#index-dllimport-function-attribute
+ */
+__declspec(dllimport) extern void * memcpy(void *, const void *, size_t);
+#endif
+
 #include "FastMemcpy.h"
 
 unsigned int gettime()

--- a/FastMemcpy_Avx.c
+++ b/FastMemcpy_Avx.c
@@ -25,6 +25,16 @@
 #error it can only be compiled under windows or unix
 #endif
 
+#ifdef __MINGW32__
+/* On MinGW and mingw-w64 targets, `memcpy()` is imported from MSVCRT.DLL.
+ * With regard to benchmarking purposes, we have to eliminate the overhead
+ * of implicit importation by specifying `dllexport` explicitly.
+ *
+ * Reference: https://gcc.gnu.org/onlinedocs/gcc/Microsoft-Windows-Function-Attributes.html#index-dllimport-function-attribute
+ */
+__declspec(dllimport) extern void * memcpy(void *, const void *, size_t);
+#endif
+
 #include "FastMemcpy_Avx.h"
 
 


### PR DESCRIPTION
…w-w64 targets.

On MinGW and mingw-w64 targets, `memcpy()` is imported from MSVCRT.DLL.
With regard to benchmarking purposes, we have to eliminate the overhead
of implicit importation by specifying `dllexport` explicitly.

Reference: https://gcc.gnu.org/onlinedocs/gcc/Microsoft-Windows-Function-Attributes.html#index-dllimport-function-attribute
Signed-off-by: Liu Hao <lh_mouse@126.com>